### PR TITLE
Fix incorrect README.md and bad whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Python Language Bindings
 
-This repository is part of the Isilon SDK, which is an evolving package of documents and files. This README describes how to install and configure Python language bindings in order to access the OneFS API on an Isilon cluster from a Python script. You can use the OneFS API to automate the configuration, maintenance, and monitoring of your Isilon cluster. 
+This repository is part of the Isilon SDK, which is an evolving package of documents and files. This README describes how to install and configure Python language bindings in order to access the OneFS API on an Isilon cluster from a Python script. You can use the OneFS API to automate the configuration, maintenance, and monitoring of your Isilon cluster.
 
 * For OneFS API reference documents, discussions, and blog posts, refer to the [OneFS SDK Info Hub](https://community.emc.com/docs/DOC-48273).
 * To browse the Isilon InsiqhtIQ statistics API, refer to the [Stat Key Browser](https://github.com/isilon/isilon_stat_browser.git) Github repository.
@@ -10,7 +10,7 @@ Python 2.7 and later.
 
 ##Install the Python language bindings
 
-You can install the isi_sdk_python library from Github using the pip command. 
+You can install the isi_sdk_python library from Github using the pip command.
 
 ```sh
 pip install git+https://github.com/isilon/isilon_sdk_python_8_0.git
@@ -24,7 +24,7 @@ Alternatively, you can clone this Github repository and run the following comman
 python setup.py install
 ```
 
-You may need to install the Python [Setuptools](http://pypi.python.org/pypi/setuptools) on your system, if they are not already installed. For instructions, see http://pypi.python.org/pypi/setuptools. 
+You may need to install the Python [Setuptools](http://pypi.python.org/pypi/setuptools) on your system, if they are not already installed. For instructions, see http://pypi.python.org/pypi/setuptools.
 
 To import the package and use the bindings, add the following line to the top of the Python scripts that you write:
 
@@ -48,8 +48,8 @@ isi_sdk.configuration.verify_ssl = False
 
 # configure host
 host = "https://<ip_address>:8080"
-apiClient = isi_sdk_python.ApiClient(host)
-protocolsApi = isi_sdk_python.ProtocolsApi(apiClient)
+apiClient = isi_sdk.ApiClient(host)
+protocolsApi = isi_sdk.ProtocolsApi(apiClient)
 
 # get all exports
 nfsExports = protocolsApi.list_nfs_exports()


### PR DESCRIPTION
isi_sdk_python in README.md should be isi_sdk unless you:
```
import isi_sdk as isi_sdk_python
```
removed trailing whitespace from README.md