### PR TITLE
Cherry pick lazy pool init from swagger-codegen

### DIFF
--- a/isilon_sdk/isilon_sdk/v9_0_0/api_client.py
+++ b/isilon_sdk/isilon_sdk/v9_0_0/api_client.py
@@ -67,7 +67,7 @@ class ApiClient(object):
             configuration = Configuration()
         self.configuration = configuration
 
-        self.pool = ThreadPool()
+        self._pool = None  # Use the pool property to lazily initialize the ThreadPool.
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -86,8 +86,15 @@ class ApiClient(object):
         self.x_csrf_token = None
 
     def __del__(self):
-        self.pool.close()
-        self.pool.join()
+        if self._pool is not None:
+            self._pool.close()
+            self._pool.join()
+
+    @property
+    def pool(self):
+        if self._pool is None:
+            self._pool = ThreadPool()
+        return self._pool
 
     @property
     def user_agent(self):

--- a/isilon_sdk/isilon_sdk/v9_1_0/api_client.py
+++ b/isilon_sdk/isilon_sdk/v9_1_0/api_client.py
@@ -67,7 +67,7 @@ class ApiClient(object):
             configuration = Configuration()
         self.configuration = configuration
 
-        self.pool = ThreadPool()
+        self._pool = None  # Use the pool property to lazily initialize the ThreadPool.
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -86,8 +86,15 @@ class ApiClient(object):
         self.x_csrf_token = None
 
     def __del__(self):
-        self.pool.close()
-        self.pool.join()
+        if self._pool is not None:
+            self._pool.close()
+            self._pool.join()
+
+    @property
+    def pool(self):
+        if self._pool is None:
+            self._pool = ThreadPool()
+        return self._pool
 
     @property
     def user_agent(self):

--- a/isilon_sdk/isilon_sdk/v9_2_0/api_client.py
+++ b/isilon_sdk/isilon_sdk/v9_2_0/api_client.py
@@ -67,7 +67,7 @@ class ApiClient(object):
             configuration = Configuration()
         self.configuration = configuration
 
-        self.pool = ThreadPool()
+        self._pool = None  # Use the pool property to lazily initialize the ThreadPool.
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -86,8 +86,15 @@ class ApiClient(object):
         self.x_csrf_token = None
 
     def __del__(self):
-        self.pool.close()
-        self.pool.join()
+        if self._pool is not None:
+            self._pool.close()
+            self._pool.join()
+
+    @property
+    def pool(self):
+        if self._pool is None:
+            self._pool = ThreadPool()
+        return self._pool
 
     @property
     def user_agent(self):

--- a/isilon_sdk/isilon_sdk/v9_2_1/api_client.py
+++ b/isilon_sdk/isilon_sdk/v9_2_1/api_client.py
@@ -67,7 +67,7 @@ class ApiClient(object):
             configuration = Configuration()
         self.configuration = configuration
 
-        self.pool = ThreadPool()
+        self._pool = None  # Use the pool property to lazily initialize the ThreadPool.
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -86,8 +86,15 @@ class ApiClient(object):
         self.x_csrf_token = None
 
     def __del__(self):
-        self.pool.close()
-        self.pool.join()
+        if self._pool is not None:
+            self._pool.close()
+            self._pool.join()
+
+    @property
+    def pool(self):
+        if self._pool is None:
+            self._pool = ThreadPool()
+        return self._pool
 
     @property
     def user_agent(self):

--- a/isilon_sdk/isilon_sdk/v9_3_0/api_client.py
+++ b/isilon_sdk/isilon_sdk/v9_3_0/api_client.py
@@ -67,7 +67,7 @@ class ApiClient(object):
             configuration = Configuration()
         self.configuration = configuration
 
-        self.pool = ThreadPool()
+        self._pool = None  # Use the pool property to lazily initialize the ThreadPool.
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -86,8 +86,15 @@ class ApiClient(object):
         self.x_csrf_token = None
 
     def __del__(self):
-        self.pool.close()
-        self.pool.join()
+        if self._pool is not None:
+            self._pool.close()
+            self._pool.join()
+
+    @property
+    def pool(self):
+        if self._pool is None:
+            self._pool = ThreadPool()
+        return self._pool
 
     @property
     def user_agent(self):

--- a/isilon_sdk/isilon_sdk/v9_4_0/api_client.py
+++ b/isilon_sdk/isilon_sdk/v9_4_0/api_client.py
@@ -67,7 +67,7 @@ class ApiClient(object):
             configuration = Configuration()
         self.configuration = configuration
 
-        self.pool = ThreadPool()
+        self._pool = None  # Use the pool property to lazily initialize the ThreadPool.
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -86,8 +86,15 @@ class ApiClient(object):
         self.x_csrf_token = None
 
     def __del__(self):
-        self.pool.close()
-        self.pool.join()
+        if self._pool is not None:
+            self._pool.close()
+            self._pool.join()
+
+    @property
+    def pool(self):
+        if self._pool is None:
+            self._pool = ThreadPool()
+        return self._pool
 
     @property
     def user_agent(self):

--- a/isilon_sdk/isilon_sdk/v9_5_0/api_client.py
+++ b/isilon_sdk/isilon_sdk/v9_5_0/api_client.py
@@ -67,7 +67,7 @@ class ApiClient(object):
             configuration = Configuration()
         self.configuration = configuration
 
-        self.pool = ThreadPool()
+        self._pool = None  # Use the pool property to lazily initialize the ThreadPool.
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
         if header_name is not None:
@@ -86,8 +86,15 @@ class ApiClient(object):
         self.x_csrf_token = None
 
     def __del__(self):
-        self.pool.close()
-        self.pool.join()
+        if self._pool is not None:
+            self._pool.close()
+            self._pool.join()
+
+    @property
+    def pool(self):
+        if self._pool is None:
+            self._pool = ThreadPool()
+        return self._pool
 
     @property
     def user_agent(self):


### PR DESCRIPTION
It appears that very new Python versions are triggering a trackback in self.pool.close() for the __del__ method of the ApiClient class. Since the OneFS API doesn't use the async methods, this change should avoid the problem.
Please let me know if I should add a version bump here too.